### PR TITLE
IApplicationView* should be handled as IntPtr.

### DIFF
--- a/source/VirtualDesktop/Interop/IVirtualDesktopNotification.cs
+++ b/source/VirtualDesktop/Interop/IVirtualDesktopNotification.cs
@@ -16,7 +16,7 @@ namespace WindowsDesktop.Interop
 
 		void VirtualDesktopDestroyed(IVirtualDesktop pDesktopDestroyed, IVirtualDesktop pDesktopFallback);
 
-		void ViewVirtualDesktopChanged(object pView);
+		void ViewVirtualDesktopChanged(IntPtr pView);
 
 		void CurrentVirtualDesktopChanged(IVirtualDesktop pDesktopOld, IVirtualDesktop pDesktopNew);
 	}

--- a/source/VirtualDesktop/VirtualDesktop.static.notification.cs
+++ b/source/VirtualDesktop/VirtualDesktop.static.notification.cs
@@ -74,7 +74,7 @@ namespace WindowsDesktop
 				Destroyed?.Invoke(this, args);
 			}
 
-			void IVirtualDesktopNotification.ViewVirtualDesktopChanged(object pView)
+			void IVirtualDesktopNotification.ViewVirtualDesktopChanged(IntPtr pView)
 			{
 				ApplicationViewChanged?.Invoke(this, EventArgs.Empty);
 			}


### PR DESCRIPTION
IVirtualDesktopNotification::ViewVirtualDesktopChanged gets one of the pointer to IApplicationView interface.
But the pointer could not be cast to an object, should be handled as IntPtr value.

The PR resolve the problem #2 .