### PR TITLE
Clear out old COM objects when Virtual Desktops change

### DIFF
--- a/source/VirtualDesktop/Interop/ComObjects.cs
+++ b/source/VirtualDesktop/Interop/ComObjects.cs
@@ -33,6 +33,7 @@ namespace WindowsDesktop.Interop
 			ApplicationViewCollection = GetApplicationViewCollection();
 
 			_virtualDesktops.Clear();
+			_listener?.Dispose();
 			_listener = VirtualDesktop.RegisterListener();
 		}
 

--- a/source/VirtualDesktop/VirtualDesktop.csproj
+++ b/source/VirtualDesktop/VirtualDesktop.csproj
@@ -68,6 +68,36 @@
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseStore|AnyCPU'">
+    <OutputPath>bin\ReleaseStore\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <DocumentationFile>bin\Release\VirtualDesktop.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <NoWarn>1591</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseStore|x64'">
+    <OutputPath>bin\x64\ReleaseStore\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseStore|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\ReleaseStore\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />

--- a/source/VirtualDesktop/VirtualDesktop.static.cs
+++ b/source/VirtualDesktop/VirtualDesktop.static.cs
@@ -60,6 +60,7 @@ namespace WindowsDesktop
 			var clearWrappers = new Action(() => {
 				var oldWrappers = Interlocked.Exchange(ref _wrappers, new ConcurrentDictionary<Guid, VirtualDesktop>());
 				foreach (var v in oldWrappers.Values) { Marshal.ReleaseComObject(v.ComObject); }
+				ComObjects.Initialize();
 			});
 
 			VirtualDesktop.Created += (o, e) => clearWrappers();

--- a/source/VirtualDesktop/VirtualDesktop.static.cs
+++ b/source/VirtualDesktop/VirtualDesktop.static.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using WindowsDesktop.Interop;
 
 namespace WindowsDesktop
@@ -11,7 +12,7 @@ namespace WindowsDesktop
 	partial class VirtualDesktop
 	{
 		private static readonly bool _isSupportedInternal = true;
-		private static readonly ConcurrentDictionary<Guid, VirtualDesktop> _wrappers = new ConcurrentDictionary<Guid, VirtualDesktop>();
+		private static ConcurrentDictionary<Guid, VirtualDesktop> _wrappers = new ConcurrentDictionary<Guid, VirtualDesktop>();
 
 		/// <summary>
 		/// Gets a value indicating whether the operating system is support virtual desktop.
@@ -55,6 +56,14 @@ namespace WindowsDesktop
 				InitializationException = ex;
 				_isSupportedInternal = false;
 			}
+
+			var clearWrappers = new Action(() => {
+				var oldWrappers = Interlocked.Exchange(ref _wrappers, new ConcurrentDictionary<Guid, VirtualDesktop>());
+				foreach (var v in oldWrappers.Values) { Marshal.ReleaseComObject(v.ComObject); }
+			});
+
+			VirtualDesktop.Created += (o, e) => clearWrappers();
+			VirtualDesktop.Destroyed += (o, e) => clearWrappers();
 
 			AppDomain.CurrentDomain.ProcessExit += (sender, args) => ComObjects.Terminate();
 		}

--- a/source/VirtualDesktop/VirtualDesktopHelper.cs
+++ b/source/VirtualDesktop/VirtualDesktopHelper.cs
@@ -14,7 +14,6 @@ namespace WindowsDesktop
 			}
 		}
 
-
 		public static bool IsCurrentVirtualDesktop(IntPtr handle)
 		{
 			ThrowIfNotSupported();


### PR DESCRIPTION
This PR re-registers ourselves when Virtual Desktops change, otherwise we're keeping around invalid Virtual Desktop objects forever