### PR TITLE
Fix crash when multiple threads may exist.

### DIFF
--- a/source/VirtualDesktop/Internal/RawWindow.cs
+++ b/source/VirtualDesktop/Internal/RawWindow.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Interop;
+using System.Windows.Threading;
 using WindowsDesktop.Interop;
 
 namespace WindowsDesktop.Internal
@@ -28,7 +27,9 @@ namespace WindowsDesktop.Internal
 		public virtual void Close()
 		{
 			this.Source?.RemoveHook(this.WndProc);
-			this.Source?.Dispose();
+			// Source could have been created on a different thread, which means we 
+			// have to Dispose of it on the UI thread or it will crash.
+			this.Source?.Dispatcher?.BeginInvoke(DispatcherPriority.Send, (Action)(() => this.Source?.Dispose()));
 			this.Source = null;
 
 			NativeMethods.CloseWindow(this.Handle);

--- a/source/VirtualDesktop/VirtualDesktopProvider.cs
+++ b/source/VirtualDesktop/VirtualDesktopProvider.cs
@@ -26,7 +26,7 @@ namespace WindowsDesktop
 		internal ComObjects ComObjects { get; private set; }
 		
 		public Task Initialize()
-			=> this.Initialize(TaskScheduler.FromCurrentSynchronizationContext());
+			=> this.Initialize(TaskScheduler.Current);
 
 		public Task Initialize(TaskScheduler scheduler)
 		{


### PR DESCRIPTION
Based on a crash I experienced in an app I am developing, it appears that sometimes when the app is shutting down, the disposal will not happen from the UI thread, and `Dispose()` on the `HwndSource` causes an `InvalidOperationException`.

By running the Dispose on the UI thread immediately, disposal happens, and no crash is seen.