### PR TITLE
_isSupported is always true …

### DIFF
--- a/source/VirtualDesktop/VirtualDesktop.static.cs
+++ b/source/VirtualDesktop/VirtualDesktop.static.cs
@@ -9,7 +9,7 @@ namespace WindowsDesktop
 {
 	partial class VirtualDesktop
 	{
-		private static bool? _isSupported = true;
+		private static bool? _isSupported = null;
 
 		/// <summary>
 		/// Gets a value indicating whether the operating system is support virtual desktop.


### PR DESCRIPTION
causing ProviderInternal.Initialize to never be called.

related to #30