### PR TITLE
Add synchronous Initialize method

### DIFF
--- a/samples/VirtualDesktop.Showcase/MainWindow.xaml.cs
+++ b/samples/VirtualDesktop.Showcase/MainWindow.xaml.cs
@@ -22,7 +22,7 @@ namespace VirtualDesktopShowcase
 		{
 			try
 			{
-				await VirtualDesktopProvider.Default.Initialize();
+				await VirtualDesktopProvider.Default.InitializeAsync();
 			}
 			catch (Exception ex)
 			{

--- a/source/VirtualDesktop/VirtualDesktop.static.cs
+++ b/source/VirtualDesktop/VirtualDesktop.static.cs
@@ -99,7 +99,7 @@ namespace WindowsDesktop
 #endif
 				try
 				{
-					ProviderInternal.Initialize().Wait();
+					ProviderInternal.Initialize();
 				}
 				catch (Exception ex)
 				{

--- a/source/VirtualDesktop/VirtualDesktopProvider.cs
+++ b/source/VirtualDesktop/VirtualDesktopProvider.cs
@@ -24,7 +24,14 @@ namespace WindowsDesktop
 		internal ComObjects ComObjects { get; private set; }
 
 		public Task InitializeAsync()
-			=> Task.Run(Initialize);
+			=> this.InitializeAsync(TaskScheduler.FromCurrentSynchronizationContext());
+
+		public Task InitializeAsync(TaskScheduler scheduler)
+			=> Task.Factory.StartNew(
+				() => this.Initialize(),
+				CancellationToken.None,
+				TaskCreationOptions.None,
+				scheduler);
 
 		public void Initialize()
 		{


### PR DESCRIPTION
This renames the current Task `Initialize` methods to `InitializeAsync`, and adds `void Initialize`.
It's a breaking change, but only affects v3 (which is in beta).
I didn't include the cached `_initializationTask`, because I figure Initialize should only be called once so it's unnecessary, but LMK.

This can help as a workaround to #37.
also fixes a bug where calling initialize, enabling `AutoRestart`, then calling initialize again won't trigger `this.ComObjects.Listen()`

LMK what you think!