### PR TITLE
fix: exception in VirtualDesktopProvider.Initialize

### DIFF
--- a/source/VirtualDesktop/VirtualDesktopProvider.cs
+++ b/source/VirtualDesktop/VirtualDesktopProvider.cs
@@ -26,7 +26,7 @@ namespace WindowsDesktop
 		internal ComObjects ComObjects { get; private set; }
 		
 		public Task Initialize()
-			=> this.Initialize(TaskScheduler.FromCurrentSynchronizationContext());
+			=> this.Initialize(TaskScheduler.Current);
 
 		public Task Initialize(TaskScheduler scheduler)
 		{


### PR DESCRIPTION
Fixes #37 
`TaskScheduler.FromCurrentSynchronizationContext` throws an exception when `SynchronizationContext.Current == null`. Also, I don't see why a `TaskScheduler` would have to be obtained from a `SynchronizationContext`, so I simply made it use `TaskScheduler.Current` instead.