### PR TITLE
Removed dependency for Microsoft.CodeAnalysis and System.Runtime.Loader when targeting .Net 4.7.2

### DIFF
--- a/source/VirtualDesktop/VirtualDesktop.csproj
+++ b/source/VirtualDesktop/VirtualDesktop.csproj
@@ -52,7 +52,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net472' " >
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Adding these dependencies is not necessary and adds unnecessary files (multiple MBs).