### PR TITLE
Fix not working with .NET Framework 4.7.2

### DIFF
--- a/source/VirtualDesktop/Interop/ComInterfaceAssemblyProvider.cs
+++ b/source/VirtualDesktop/Interop/ComInterfaceAssemblyProvider.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+#if !NETFRAMEWORK
 using System.Runtime.Loader;
+#endif
 using System.Text;
 using System.Text.RegularExpressions;
 using WindowsDesktop.Properties;
@@ -22,7 +24,7 @@ namespace WindowsDesktop.Interop
 		private static readonly Version _requireVersion = new Version("1.0");
 
 		private readonly string _assemblyDirectoryPath;
-		
+
 		public ComInterfaceAssemblyProvider(string assemblyDirectoryPath)
 		{
 			this._assemblyDirectoryPath = assemblyDirectoryPath ?? _defaultAssemblyDirectoryPath;
@@ -135,7 +137,11 @@ namespace WindowsDesktop.Interop
 			var result = compilation.Emit(path);
 			if (result.Success)
 			{
+#if NETFRAMEWORK
+				return Assembly.LoadFrom(path);
+#else
 				return AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+#endif
 			}
 
 			File.Delete(path);

--- a/source/VirtualDesktop/VirtualDesktop.csproj
+++ b/source/VirtualDesktop/VirtualDesktop.csproj
@@ -52,9 +52,12 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
System.Runtime.Loader is not supported on .NET Framework 4.7.2. We need to use Assembly.LoadFrom instead.