### PR TITLE
Force GC after building the interfaces.

### DIFF
--- a/source/VirtualDesktop/VirtualDesktopProvider.cs
+++ b/source/VirtualDesktop/VirtualDesktopProvider.cs
@@ -52,6 +52,7 @@ namespace WindowsDesktop
 				var assembly = new ComInterfaceAssembly(assemblyProvider.GetAssembly());
 
 				this.ComObjects = new ComObjects(assembly);
+				GC.Collect();
 			}
 		}
 


### PR DESCRIPTION
インターフェース群をビルド後に強制的にGCを走らせます。

In my environment, the memory usage has been reduced by about 50 MB (from 129.2 MB to 82 MB).
手元の環境ではメモリー使用量が 50 MB 程度 (129.2 → 82 MB) 減りました。
<img width="305" alt="enable-force-gc" src="https://user-images.githubusercontent.com/901816/91586959-14fee400-e991-11ea-99aa-941b5728d2b7.png">

Note: yellow ▼ in graph is to start GC.
注意: 図の黄色の▼は GC が実行されたときです。

---

Note: The following is a case where I didn't force GC. The part of the build where CPU usage is down matches the timing of the end of the build.
参考: 以下は GC を強制的に走らせなかったケースです。CPU使用率が下がったタイミングがビルド終了部分です。
<img width="301" alt="disable-force-gc" src="https://user-images.githubusercontent.com/901816/91587112-4b3c6380-e991-11ea-8c91-92f65910a866.png">